### PR TITLE
JKNS-539: Enable Required Build Steps

### DIFF
--- a/.tekton/adambkaplan-go-init-4-17-pull-request.yaml
+++ b/.tekton/adambkaplan-go-init-4-17-pull-request.yaml
@@ -28,6 +28,12 @@ spec:
     value: 5d
   - name: dockerfile
     value: ./Containerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/adambkaplan-go-init-4-17-push.yaml
+++ b/.tekton/adambkaplan-go-init-4-17-push.yaml
@@ -25,6 +25,12 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-tools-jenkins-tenant/adambkaplan-go-init-4-17:{{revision}}
   - name: dockerfile
     value: ./Containerfile
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
- Enable source image build
- Enable [hermetic build](https://konflux-ci.dev/docs/how-tos/configuring/hermetic-builds/) with gomod-based [cachi2 prefetch](https://konflux-ci.dev/docs/how-tos/configuring/prefetching-dependencies/).